### PR TITLE
Add license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,23 @@
+ISC License
+
+Copyright (c) 2020, Suecra
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+
+DISCLAIMER:
+
+All visual and audio assets included in this repository are property of
+Nintendo, GameFreak, Creatures Inc, and The Pokemon Company unless
+otherwise stated. Said assets cannot be used commerically without
+explicit permission from their respective owners.


### PR DESCRIPTION
This PR is fairly simple and adds a LICENSE file.
The license file includes the ISC license, which is functionally equivalent to the BSD 2-Clause and MIT licenses, just simplified as much of the language is no longer needed in modern copyright law (BERN).

I've also added a separate disclaimer about assets owned by GameFreak, Nintendo, etc, stating that they are not covered under the ISC license and are instead full property of their respective owners.

Feel free to edit it however you'd like. I had the idea of having one file called CODE_LICENSE and one called ASSET_LICENSE for clarity. If you'd prefer that, let me know.